### PR TITLE
fix: add primary_keys for 'export' endpoint

### DIFF
--- a/tap_mixpanel/streams.py
+++ b/tap_mixpanel/streams.py
@@ -507,6 +507,7 @@ class Export(MixPanel):
     bookmark_query_field_from = "from_date"
     bookmark_query_field_to = "to_date"
     replication_method = "INCREMENTAL"
+    key_properties = ["event","distinct_id","time"]
     params = {}
 
     def get_and_transform_records(
@@ -535,11 +536,9 @@ class Export(MixPanel):
                 transformed_data.append(transformed_record)
 
                 # Check for missing keys
-                for key in self.key_properties:
-                    val = transformed_record.get(key)
-                    if not val:
-                        LOGGER.error('Error: Missing Key')
-                        raise 'Missing Key'
+                if not any(transformed_record.get(key) for key in self.key_properties):
+                    LOGGER.error('Error: Missing Key')
+                    raise 'Missing Keys'
 
                 if len(transformed_data) == limit:
                     # Process full batch (limit = 250) records

--- a/tap_mixpanel/streams.py
+++ b/tap_mixpanel/streams.py
@@ -507,7 +507,6 @@ class Export(MixPanel):
     bookmark_query_field_from = "from_date"
     bookmark_query_field_to = "to_date"
     replication_method = "INCREMENTAL"
-    key_properties = ["event","distinct_id","time"]
     params = {}
 
     def get_and_transform_records(
@@ -536,9 +535,11 @@ class Export(MixPanel):
                 transformed_data.append(transformed_record)
 
                 # Check for missing keys
-                if not any(transformed_record.get(key) for key in self.key_properties):
-                    LOGGER.error('Error: Missing Key')
-                    raise 'Missing Keys'
+                for key in self.key_properties:
+                    val = transformed_record.get(key)
+                    if not val:
+                        LOGGER.error('Error: Missing Key')
+                        raise 'Missing Key'
 
                 if len(transformed_data) == limit:
                     # Process full batch (limit = 250) records

--- a/tap_mixpanel/streams.py
+++ b/tap_mixpanel/streams.py
@@ -507,6 +507,7 @@ class Export(MixPanel):
     bookmark_query_field_from = "from_date"
     bookmark_query_field_to = "to_date"
     replication_method = "INCREMENTAL"
+    key_properties = ["event","distinct_id","time"]
     params = {}
 
     def get_and_transform_records(
@@ -535,11 +536,9 @@ class Export(MixPanel):
                 transformed_data.append(transformed_record)
 
                 # Check for missing keys
-                for key in self.key_properties:
-                    val = transformed_record.get(key)
-                    if not val:
-                        LOGGER.error('Error: Missing Key')
-                        raise 'Missing Key'
+                if not any(transformed_record.get(key) for key in self.key_properties):
+                    LOGGER.error('Error: Missing Keys')
+                    raise 'Missing Keys'
 
                 if len(transformed_data) == limit:
                     # Process full batch (limit = 250) records


### PR DESCRIPTION
# Description of change
This PR details the issue being observed with replication of records in "Export" endpoint due to the absence of Primary keys for the same

# Changes
- Fields _viz._ "event", "time" and "distinct_id" has been added as primary Key
- condition to handle missing primary Keys has been updated for new primary keys which checks if none of the mentioned primary key is present, it the SYNC will fail.
 
# Testing
Thorough testing has been done for export endpoint.

# Change Type
:white_large_square: New feature (non-breaking change which adds functionality)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:white_large_square: Refactor
:white_large_square: Breaking change (fix or feature that would cause existing functionality to not work as expected)
:white_large_square: This change requires a documentation update (edited)
