### PR TITLE
🚸 :fix: missing pk for export

### DIFF
--- a/tap_mixpanel/streams.py
+++ b/tap_mixpanel/streams.py
@@ -536,10 +536,14 @@ class Export(MixPanel):
                 transformed_data.append(transformed_record)
 
                 # Check for missing keys
-                if not any(transformed_record.get(key) for key in self.key_properties):
+                missing_keys = [ key for key in self.key_properties if not transformed_record.get(key)]
+                if len(missing_keys) == len(self.key_properties):
                     LOGGER.error('Error: Missing Keys')
                     raise 'Missing Keys'
-
+                else:
+                    for key in self.key_properties:
+                        transformed_record[key] = ""
+                
                 if len(transformed_data) == limit:
                     # Process full batch (limit = 250) records
                     #   and get the max_bookmark_value and record_count

--- a/tap_mixpanel/streams.py
+++ b/tap_mixpanel/streams.py
@@ -540,8 +540,8 @@ class Export(MixPanel):
                 if len(missing_keys) == len(self.key_properties):
                     LOGGER.error('Error: Missing Keys')
                     raise 'Missing Keys'
-                else:
-                    for key in self.key_properties:
+                elif missing_keys:
+                    for key in missing_keys:
                         transformed_record[key] = ""
                 
                 if len(transformed_data) == limit:


### PR DESCRIPTION
# Description
This PR details the issue caused due to missing distinct_id in the record.

# Issue
 "distinct_id" being the primary Key was missing in the record which created a "NULL Value Violation of Primary Key" on Target-Postgres.

# Change
1. distinct_id has been made 'empty string' to avoid the edge case.

# Change Type
:white_large_square: New feature (non-breaking change which adds functionality)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:white_large_square: Refactor
:white_large_square: Breaking change (fix or feature that would cause existing functionality to not work as expected)
:white_large_square: This change requires a documentation update (edited)
